### PR TITLE
Fixes authorization not being send in post, put and patch requests

### DIFF
--- a/src/dnsimple.rs
+++ b/src/dnsimple.rs
@@ -501,24 +501,30 @@ impl Client {
     }
 
     pub fn build_post_request(&self, path: &&str) -> Request {
-        self._agent
+        let request = self
+            ._agent
             .post(&self.url(path))
             .set("User-Agent", &self.user_agent)
-            .set("Accept", "application/json")
+            .set("Accept", "application/json");
+        self.add_headers_to_request(request)
     }
 
     pub fn build_put_request(&self, path: &&str) -> Request {
-        self._agent
+        let request = self
+            ._agent
             .put(&self.url(path))
             .set("User-Agent", &self.user_agent)
-            .set("Accept", "application/json")
+            .set("Accept", "application/json");
+        self.add_headers_to_request(request)
     }
 
     pub fn build_patch_request(&self, path: &&str) -> Request {
-        self._agent
+        let request = self
+            ._agent
             .request("PATCH", &self.url(path))
             .set("User-Agent", &self.user_agent)
-            .set("Accept", "application/json")
+            .set("Accept", "application/json");
+        self.add_headers_to_request(request)
     }
 
     fn build_delete_request(&self, path: &&str) -> Request {


### PR DESCRIPTION
There was a bug in which on post, put and patch the authorization code wasn't sent in the headers. This PR fixes the issue.