### PR TITLE
No longer require `contact_id` to purchase LetsEncrypt certificates

### DIFF
--- a/src/dnsimple/certificates.rs
+++ b/src/dnsimple/certificates.rs
@@ -10,6 +10,7 @@ pub struct Certificate {
     /// The associated domain ID.
     pub domain_id: u64,
     /// The associated contact ID.
+    #[deprecated]
     pub contact_id: u64,
     /// The certificate name.
     pub name: String,
@@ -94,8 +95,6 @@ pub struct LetsEncryptPurchaseRenewal {
 /// The payload for purchasing a Let's Encrypt Certificate
 #[derive(Debug, Deserialize, Serialize)]
 pub struct LetsEncryptPurchasePayload {
-    /// The ID of an existing contact in your account.
-    pub contact_id: u64,
     /// Set to true to enable the auto-renewal of the certificate.
     pub auto_renew: bool,
     /// The certificate name.
@@ -284,7 +283,6 @@ impl Certificates<'_> {
     ///
     /// let client = new_client(true, String::from("AUTH_TOKEN"));
     /// let payload = LetsEncryptPurchasePayload {
-    ///     contact_id: 42,
     ///     auto_renew: true,
     ///     name: String::from("secret"),
     ///     alternate_names: vec![],

--- a/tests/certificates_test.rs
+++ b/tests/certificates_test.rs
@@ -148,7 +148,6 @@ fn test_purchase_letsencrypt_certificate() {
     let domain = "example.com";
 
     let payload = LetsEncryptPurchasePayload {
-        contact_id: 1010,
         auto_renew: false,
         name: String::from("test-certificate"),
         alternate_names: vec![],


### PR DESCRIPTION
We no longer require a contact_id to be provided to be able to purchase a Lets Encrypt certificate.