### PR TITLE
Dissallow Expect, Unwrap, and Panics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: rustfmt check
         run: cargo fmt -- --check
       - name: Clippy check
-        run: cargo clippy -- -D warnings
+        run: cargo clippy -- -D warnings cargo -D clippy::expect_used -D clippy::panic  -D clippy::unwrap_used
   slack-workflow-status:
     if: always()
     name: Post Workflow Status To Slack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: rustfmt check
         run: cargo fmt -- --check
       - name: Clippy check
-        run: cargo clippy -- -D warnings cargo -D clippy::expect_used -D clippy::panic  -D clippy::unwrap_used
+        run: cargo clippy -- -D warnings -D clippy::expect_used -D clippy::panic -D clippy::unwrap_used
   slack-workflow-status:
     if: always()
     name: Post Workflow Status To Slack


### PR DESCRIPTION
These are dangerous for an API client to have. We should always pass an error up to the application, not invoke panic.