### PR TITLE
Correct string slice deference

### DIFF
--- a/src/dnsimple/services.rs
+++ b/src/dnsimple/services.rs
@@ -71,7 +71,7 @@ impl Services<'_> {
     ) -> Result<DNSimpleResponse<Vec<Service>>, DNSimpleError> {
         let path = "/services";
 
-        self.client.get::<ServicesEndpoint>(&*path, options)
+        self.client.get::<ServicesEndpoint>(path, options)
     }
 
     /// Retrieve a service

--- a/src/dnsimple/tlds.rs
+++ b/src/dnsimple/tlds.rs
@@ -84,7 +84,7 @@ impl Tlds<'_> {
     ) -> Result<DNSimpleResponse<Vec<Tld>>, DNSimpleError> {
         let path = "/tlds";
 
-        self.client.get::<ListTldsEndpoint>(&*path, options)
+        self.client.get::<ListTldsEndpoint>(path, options)
     }
 
     /// Retrieves the details of a supported TLD.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 use ureq::{Response, Transport};
 
 /// Represents the possible errors thrown while interacting with the DNSimple API
-#[derive(Error, Deserialize, Serialize, Debug, PartialEq)]
+#[derive(Error, Deserialize, Serialize, Debug, PartialEq, Eq)]
 pub enum DNSimpleError {
     #[error("Authentication failed")]
     Unauthorized,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -26,7 +26,7 @@ pub enum DNSimpleError {
     ServiceUnavailable,
     #[error("You exceeded the allowed number of requests per hour and your request has temporarily been throttled.")]
     TooManyRequests,
-    #[error("Transport Error – {0}({1})")]
+    #[error("Transport Error - {0}({1})")]
     Transport(String, String),
     #[error("Deserialization Error {0}")]
     Deserialization(String),

--- a/tests/errors_tests.rs
+++ b/tests/errors_tests.rs
@@ -53,5 +53,5 @@ fn transport() {
     let response = client.identity().whoami();
     let error = response.unwrap_err();
 
-    assert_eq!("Transport Error – 501(Mock Not Found)", error.to_string());
+    assert_eq!("Transport Error - 501(Mock Not Found)", error.to_string());
 }


### PR DESCRIPTION
This PR addresses the failing linter checks. It was raised that we were dereferencing a string slice expect for the variable not to be a string literal.