### PR TITLE
Expose specific model errors on validation error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ thiserror = "1.0"
 
 [dev-dependencies]
 mockito = "0.31"
+assert_matches = "1.5"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,8 +10,11 @@ pub enum DNSimpleError {
     Unauthorized,
     #[error("Bad Gateway")]
     BadGateway,
-    #[error("{0}")]
-    BadRequest(String, Option<Value>),
+    #[error("{message}")]
+    BadRequest {
+        message: String,
+        attribute_errors: Option<Value>,
+    },
     #[error("{0}")]
     GatewayTimeout(String),
     #[error("Method not Allowed")]
@@ -58,7 +61,10 @@ impl DNSimpleError {
 
     fn bad_request(response: Response) -> DNSimpleError {
         match Self::response_to_json(response) {
-            Ok(json) => Self::BadRequest(Self::message_in(&json), Some(json["errors"].clone())),
+            Ok(json) => Self::BadRequest {
+                message: Self::message_in(&json),
+                attribute_errors: Some(json["errors"].clone()),
+            },
             Err(error) => error,
         }
     }

--- a/tests/errors_tests.rs
+++ b/tests/errors_tests.rs
@@ -1,9 +1,7 @@
-use crate::assert_matches::assert_matches;
 use crate::common::setup_mock_for;
+use assert_matches::assert_matches;
 use dnsimple::errors::DNSimpleError;
 use serde_json::json;
-#[macro_use]
-extern crate assert_matches;
 
 mod common;
 

--- a/tests/errors_tests.rs
+++ b/tests/errors_tests.rs
@@ -1,4 +1,9 @@
+use crate::assert_matches::assert_matches;
 use crate::common::setup_mock_for;
+use dnsimple::errors::DNSimpleError;
+use serde_json::json;
+#[macro_use]
+extern crate assert_matches;
 
 mod common;
 
@@ -11,6 +16,10 @@ fn validation_error() {
     let error = response.unwrap_err();
 
     assert_eq!("Validation failed", error.to_string());
+    assert_matches!(error, DNSimpleError::BadRequest{ message, attribute_errors } => {
+      assert_eq!("Validation failed", message);
+      assert_eq!(json!({"address1":["can't be blank"],"city":["can't be blank"],"country":["can't be blank"],"email":["can't be blank","is an invalid email address"],"first_name":["can't be blank"],"last_name":["can't be blank"],"phone":["can't be blank","is probably not a phone number"],"postal_code":["can't be blank"],"state_province":["can't be blank"]}), attribute_errors.unwrap());
+    })
 }
 
 #[test]


### PR DESCRIPTION
Our error responses sometimes include an errors entry with details about errors on the attributes of the specific resource. We handle those errors via DNSimpleError, but we are only considering the message.

This PR adds the message and attribute_errors to the BadRequest enum value for DNSimpleError so that with some pattern matching the detailed errors can be retrieved.