### PR TITLE
Fix serialized name of ZoneRecordPayload::record_type

### DIFF
--- a/src/dnsimple/zones_records.rs
+++ b/src/dnsimple/zones_records.rs
@@ -40,6 +40,7 @@ pub struct ZoneRecordPayload {
     /// The record name (without the domain name).
     pub name: String,
     /// The type of record, in uppercase.
+    #[serde(rename = "type")]
     pub record_type: String,
     /// The plain-text record content.
     pub content: String,


### PR DESCRIPTION
This field seems to have been missed in adding annotations to `record_type` fields