### PR TITLE
Use CARGO_PKG_VERSION instead of hard-coding version value, set MSRV, and bump Mockito to 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
     name: Rust
     steps:
       - uses: actions/checkout@v3
+      - name: Install MSRV Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          components: clippy, rustfmt
+          default: true
+          toolchain: '1.65.0'
       - name: Build
         run: cargo build --verbose
       - name: Run tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,39 +19,33 @@ cd dnsimple-rust
 
 The following instructions uses `$VERSION` as a placeholder, where `$VERSION` is a `MAJOR.MINOR.BUGFIX` release such as `1.2.0`.
 
-1. Set the version in `dnsimple.rs`:
-
-    ```rust
-    const VERSION: &str = "0.1.0";
-    ```
-
-2. Set the version in `Cargo.toml`
+1. Set the version in `Cargo.toml`
 
     ```yaml
     version = "0.1.0"
     ```
 
-4. Run the test suite and ensure all the tests pass.
+1. Run the test suite and ensure all the tests pass.
 
-5. Finalize the `## main` section in `CHANGELOG.md` assigning the version.
+1. Finalize the `## main` section in `CHANGELOG.md` assigning the version.
 
-6. Commit and push the changes
+1. Commit and push the changes
 
     ```shell
     git commit -a -m "Release $VERSION"
     git push origin main
     ```
 
-7. Wait for CI to complete.
+1. Wait for CI to complete.
 
-8. Create a signed tag.
+1. Create a signed tag.
 
     ```shell
     git tag -a v$VERSION -s -m "Release $VERSION"
     git push origin --tags
     ```
 
-9. The `release` GitHub action should take it from here and release the package to crates.io
+1. The `release` GitHub action should take it from here and release the package to crates.io
 
 ## Testing
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/dnsimple/dnsimple-rust"
 keywords = ["DNS", "domain", "management", "automation"]
 categories = ["api-bindings"]
 include = ["src/**/*.rs", "README.md", "LICENSE.txt", "CHANGELOG.md"]
+rust-version = "1.65.0" # We use deps that use let-else statements.
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ serde_json = { version = "1.0", features = ["raw_value"] }
 thiserror = "1.0"
 
 [dev-dependencies]
-mockito = "0.32"
 assert_matches = "1.5"
+mockito = "1.0"

--- a/src/dnsimple.rs
+++ b/src/dnsimple.rs
@@ -42,7 +42,7 @@ pub mod webhooks;
 pub mod zones;
 pub mod zones_records;
 
-const VERSION: &str = "0.4.0";
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 const DEFAULT_USER_AGENT: &str = "dnsimple-rust/";
 
 const API_VERSION: &str = "v2";

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,5 @@
 use dnsimple::dnsimple::{new_client, Client};
-use mockito::{Mock, Server};
+use mockito::{Server, ServerGuard};
 use std::fs;
 
 /// Creates a mockserver and a client (changing the url of the client
@@ -13,7 +13,7 @@ use std::fs;
 /// `path`: the path in the server (i.e. `/whoami`)
 /// `method`: the HTTP method we are going to use (GET, POST, DELETE, ...)
 ///
-pub fn setup_mock_for(path: &str, fixture: &str, method: &str) -> (Client, Mock) {
+pub fn setup_mock_for(path: &str, fixture: &str, method: &str) -> (Client, ServerGuard) {
     let path = format!("/v2{}", path);
     let fixture = format!("./tests/fixtures/v2/api/{}.http", fixture);
 
@@ -25,7 +25,7 @@ pub fn setup_mock_for(path: &str, fixture: &str, method: &str) -> (Client, Mock)
     let body = lines.last();
 
     let mut server = Server::new();
-    let mock = server
+    server
         .mock(method, path.as_str())
         .with_header("X-RateLimit-Limit", "2")
         .with_header("X-RateLimit-Remaining", "2")
@@ -36,5 +36,5 @@ pub fn setup_mock_for(path: &str, fixture: &str, method: &str) -> (Client, Mock)
 
     let mut client = new_client(true, String::from("some-token"));
     client.set_base_url(&server.url());
-    (client, mock)
+    (client, server)
 }


### PR DESCRIPTION
We can use the [CARGO_PKG_VERSION](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates) build environment variable for getting our library version, which is always provided by Cargo, instead of manually hard-coding it in the source.

Set the MSRV of our library.

Bump Mockito to 1.0.