### PR TITLE
Add support to activate and deactivate DNS services for a zone

### DIFF
--- a/src/dnsimple/zones.rs
+++ b/src/dnsimple/zones.rs
@@ -1,6 +1,7 @@
 use crate::dnsimple::{Client, DNSimpleResponse, Endpoint, RequestOptions};
 use crate::errors::DNSimpleError;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// Represents a zone in DNSimple
 #[derive(Debug, Deserialize, Serialize)]
@@ -39,6 +40,18 @@ impl Endpoint for ListZonesEndpoint {
     type Output = Vec<Zone>;
 }
 
+struct ActivateDnsEndpoint;
+
+impl Endpoint for ActivateDnsEndpoint {
+    type Output = Zone;
+}
+
+struct DeactivateDnsEndpoint;
+
+impl Endpoint for DeactivateDnsEndpoint {
+    type Output = Zone;
+}
+
 struct ZoneEndpoint;
 
 impl Endpoint for ZoneEndpoint {
@@ -65,6 +78,38 @@ pub struct Zones<'a> {
 }
 
 impl Zones<'_> {
+    /// Activates DNS resolution for the zone in the account.
+    ///
+    /// # Arguments
+    ///
+    /// `account_id`: The account ID
+    /// `zone_name`: The zone name
+    pub fn activate_dns(
+        &self,
+        account_id: u64,
+        zone_name: &str,
+    ) -> Result<DNSimpleResponse<Zone>, DNSimpleError> {
+        let path = format!("/{}/zones/{}/activation", account_id, zone_name);
+
+        self.client.put::<ActivateDnsEndpoint>(&path, Value::Null)
+    }
+
+    /// Deactivates DNS resolution for the zone in the account.
+    ///
+    /// # Arguments
+    ///
+    /// `account_id`: The account ID
+    /// `zone_name`: The zone name
+    pub fn deactivate_dns(
+        &self,
+        account_id: u64,
+        zone_name: &str,
+    ) -> Result<DNSimpleResponse<Zone>, DNSimpleError> {
+        let path = format!("/{}/zones/{}/activation", account_id, zone_name);
+
+        self.client.delete_with_response::<ActivateDnsEndpoint>(&path)
+    }
+
     /// Lists the zones in the account.
     ///
     /// # Arguments

--- a/tests/fixtures/v2/api/activateZoneService/success.http
+++ b/tests/fixtures/v2/api/activateZoneService/success.http
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 08 Aug 2023 04:19:23 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2399
+X-RateLimit-Reset: 1691471963
+X-WORK-WITH-US: Love automation? So do we! https://dnsimple.com/jobs
+ETag: W/"fe6afd982459be33146933235343d51d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 8e8ac535-9f46-4304-8440-8c68c30427c3
+X-Runtime: 0.176579
+Strict-Transport-Security: max-age=63072000
+
+{"data":{"id":1,"account_id":1010,"name":"example.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/tests/fixtures/v2/api/deactivateZoneService/success.http
+++ b/tests/fixtures/v2/api/deactivateZoneService/success.http
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 08 Aug 2023 04:19:52 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1691471962
+X-WORK-WITH-US: Love automation? So do we! https://dnsimple.com/jobs
+ETag: W/"5f30a37d01b99bb9e620ef1bbce9a014"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: d2f7bba4-4c81-4818-81d2-c9bbe95f104e
+X-Runtime: 0.133278
+Strict-Transport-Security: max-age=63072000
+
+{"data":{"id":1,"account_id":1010,"name":"example.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/tests/zones_test.rs
+++ b/tests/zones_test.rs
@@ -2,6 +2,50 @@ use crate::common::setup_mock_for;
 mod common;
 
 #[test]
+fn activate_zone_dns_test() {
+    let setup = setup_mock_for("/1010/zones/example.com/activation", "activateZoneService/success", "PUT");
+    let client = setup.0;
+    let account_id = 1010;
+    let zone = "example.com";
+
+    let zone = client
+        .zones()
+        .activate_dns(account_id, zone)
+        .unwrap()
+        .data
+        .unwrap();
+
+    assert_eq!(1, zone.id);
+    assert_eq!(1010, zone.account_id);
+    assert_eq!("example.com", zone.name);
+    assert!(!zone.reverse);
+    assert_eq!("2015-04-23T07:40:03Z", zone.created_at);
+    assert_eq!("2015-04-23T07:40:03Z", zone.updated_at);
+}
+
+#[test]
+fn deactivate_zone_dns_test() {
+    let setup = setup_mock_for("/1010/zones/example.com/activation", "deactivateZoneService/success", "DELETE");
+    let client = setup.0;
+    let account_id = 1010;
+    let zone = "example.com";
+
+    let zone = client
+        .zones()
+        .deactivate_dns(account_id, zone)
+        .unwrap()
+        .data
+        .unwrap();
+
+    assert_eq!(1, zone.id);
+    assert_eq!(1010, zone.account_id);
+    assert_eq!("example.com", zone.name);
+    assert!(!zone.reverse);
+    assert_eq!("2015-04-23T07:40:03Z", zone.created_at);
+    assert_eq!("2015-04-23T07:40:03Z", zone.updated_at);
+}
+
+#[test]
 fn list_zones_test() {
     let setup = setup_mock_for("/1010/zones", "listZones/success", "GET");
     let client = setup.0;


### PR DESCRIPTION
This PR implements https://github.com/dnsimple/dnsimple-developer/pull/502 which allows for the management of DNS resolution for a particular zone.

Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/3
Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/2