### PR TITLE
Add missing attributes to the Zone API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
+ENHANCEMENTS:
+
+- NEW: Added `Secondary`, `LastTransferredAt`, `Active` to `Zone` (dnsimple/dnsimple-rust)
+
 ## 0.5.0
 
 FEATURES:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,5 @@ thiserror = "1.0"
 
 [dev-dependencies]
 assert_matches = "1.5"
-mockito = "1.0"
+mockito = "= 1.1.0"
+colored = "= 2.0.0"

--- a/src/dnsimple/zones.rs
+++ b/src/dnsimple/zones.rs
@@ -14,6 +14,13 @@ pub struct Zone {
     pub name: String,
     /// True if the zone is a reverse zone.
     pub reverse: bool,
+    /// True if the zone is a secondary zone.
+    pub secondary: bool,
+    /// Last time the zone was transferred.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_transferred_at: Option<String>,
+    /// True if the zone is active.
+    pub active: bool,
     ///  When the zone was created in DNSimple.
     pub created_at: String,
     ///  When the zone was created in DNSimple.

--- a/tests/fixtures/v2/api/getZone/success.http
+++ b/tests/fixtures/v2/api/getZone/success.http
@@ -13,4 +13,4 @@ X-Request-Id: 93182033-a215-484e-a107-5235fa48001c
 X-Runtime: 0.177942
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}
+{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/tests/fixtures/v2/api/listZones/success.http
+++ b/tests/fixtures/v2/api/listZones/success.http
@@ -13,4 +13,4 @@ X-Request-Id: 01be9fa5-3a00-4d51-a927-f17587cb67ec
 X-Runtime: 0.037083
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"},{"id":2,"account_id":1010,"name":"example-beta.com","reverse":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}
+{"data":[{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"},{"id":2,"account_id":1010,"name":"example-beta.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}

--- a/tests/zones_test.rs
+++ b/tests/zones_test.rs
@@ -74,6 +74,9 @@ fn list_zones_test() {
     assert_eq!(1010, zone.account_id);
     assert_eq!("example-alpha.com", zone.name);
     assert!(!zone.reverse);
+    assert!(!zone.secondary);
+    assert!(zone.last_transferred_at.is_none());
+    assert!(zone.active);
     assert_eq!("2015-04-23T07:40:03Z", zone.created_at);
     assert_eq!("2015-04-23T07:40:03Z", zone.updated_at);
 }
@@ -96,6 +99,9 @@ fn get_zone_test() {
     assert_eq!(1010, zone.account_id);
     assert_eq!("example-alpha.com", zone.name);
     assert!(!zone.reverse);
+    assert!(!zone.secondary);
+    assert!(zone.last_transferred_at.is_none());
+    assert!(zone.active);
     assert_eq!("2015-04-23T07:40:03Z", zone.created_at);
     assert_eq!("2015-04-23T07:40:03Z", zone.updated_at);
 }


### PR DESCRIPTION
This PR adds [missing attributes](https://github.com/dnsimple/dnsimple-developer/pull/542) of the Zone response:

- `secondary`, `last_transferred_at`, `active` to `Zone` struct

Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/17