### PR TITLE
Patch cycle - 2024 / Cycle 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  MSRV: '1.76'
+  MSRV: '1.83'
 
 jobs:
   check:
@@ -48,7 +48,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - '1.76'
+          - '1.83'
     steps:
     - uses: actions/checkout@v4
     - uses: taiki-e/install-action@protoc

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 *.sw[po]
 Cargo.lock
 .idea
+.tool-versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 - CHANGED: Deprecated `from` and `to` fields in `EmailForward`
 - CHANGED: Drop support for Rust < 1.83
 - CHANGED: Add support for Rust 1.83
+- CHANGED: `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 ## main
 
 - CHANGED: Deprecated `from` and `to` fields in `EmailForward`
+- CHANGED: Drop support for Rust < 1.83
+- CHANGED: Add support for Rust 1.83
 
 ## 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ Contibutions are welcomed. Please open an issue to discuss the changes before op
 
 ## License
 
-Copyright (c) 2015-2022 DNSimple Corporation. This is Free Software distributed under the MIT license.
+Copyright (c) 2015-2024 DNSimple Corporation. This is Free Software distributed under the MIT license.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Rust client for the [DNSimple API v2](https://developer.dnsimple.com/v2/).
 
 ## Requirements
 
-- TBD
+- Rust: 1.83+
 
 ## Usage
 

--- a/src/dnsimple/domains_collaborators.rs
+++ b/src/dnsimple/domains_collaborators.rs
@@ -67,7 +67,9 @@ impl Domains<'_> {
     /// `domain_id`: The ID of the domain we want to list the collaborators from
     /// `options`: The `RequestOptions`
     ///            - Pagination
-    #[deprecated(note = "`DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.")]
+    #[deprecated(
+        note = "`DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature."
+    )]
     pub fn list_collaborators(
         &self,
         account_id: u64,
@@ -103,7 +105,9 @@ impl Domains<'_> {
     /// `account_id`: The account ID
     /// `domain_id`: The ID of the domain we want to list the collaborators of
     /// `email`: The email of the collaborator to be added
-    #[deprecated(note = "`DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.")]
+    #[deprecated(
+        note = "`DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature."
+    )]
     pub fn add_collaborator(
         &self,
         account_id: u64,
@@ -140,7 +144,9 @@ impl Domains<'_> {
     /// `account_id`: The account ID
     /// `domain_id`: The ID of the domain we want to permanently delete
     /// `collaborator_id`: The id of the collaborator we want to remove from the domain
-    #[deprecated(note = "`DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.")]
+    #[deprecated(
+        note = "`DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature."
+    )]
     pub fn remove_collaborator(
         &self,
         account_id: u64,

--- a/src/dnsimple/domains_collaborators.rs
+++ b/src/dnsimple/domains_collaborators.rs
@@ -67,6 +67,7 @@ impl Domains<'_> {
     /// `domain_id`: The ID of the domain we want to list the collaborators from
     /// `options`: The `RequestOptions`
     ///            - Pagination
+    #[deprecated(note = "`DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.")]
     pub fn list_collaborators(
         &self,
         account_id: u64,
@@ -102,6 +103,7 @@ impl Domains<'_> {
     /// `account_id`: The account ID
     /// `domain_id`: The ID of the domain we want to list the collaborators of
     /// `email`: The email of the collaborator to be added
+    #[deprecated(note = "`DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.")]
     pub fn add_collaborator(
         &self,
         account_id: u64,
@@ -138,6 +140,7 @@ impl Domains<'_> {
     /// `account_id`: The account ID
     /// `domain_id`: The ID of the domain we want to permanently delete
     /// `collaborator_id`: The id of the collaborator we want to remove from the domain
+    #[deprecated(note = "`DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.")]
     pub fn remove_collaborator(
         &self,
         account_id: u64,

--- a/tests/domains_collaborators_test.rs
+++ b/tests/domains_collaborators_test.rs
@@ -2,6 +2,7 @@ use crate::common::setup_mock_for;
 mod common;
 
 #[test]
+#[allow(deprecated)]
 fn test_list_collaborators() {
     let setup = setup_mock_for(
         "/1385/domains/1/collaborators",
@@ -40,6 +41,7 @@ fn test_list_collaborators() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_add_collaborator_success() {
     let setup = setup_mock_for(
         "/1385/domains/1/collaborators",
@@ -72,6 +74,7 @@ fn test_add_collaborator_success() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_add_collaborator_invite_success() {
     let setup = setup_mock_for(
         "/1385/domains/1/collaborators",
@@ -102,6 +105,7 @@ fn test_add_collaborator_invite_success() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_remove_collaborator() {
     let setup = setup_mock_for(
         "/1385/domains/1/collaborators/100",


### PR DESCRIPTION
The changes to go out in the next version (2.0.0) are:

- CHANGED: Deprecated `from` and `to` fields in `EmailForward`
- CHANGED: Drop support for Rust < 1.83
- CHANGED: Add support for Rust 1.83
- CHANGED: `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.

Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/231