### PR TITLE
skip serializing if options is none

### DIFF
--- a/src/dnsimple/zones_records.rs
+++ b/src/dnsimple/zones_records.rs
@@ -65,6 +65,7 @@ pub struct ZoneRecordUpdatePayload {
     /// The priority value, if the type of record accepts a priority.
     pub priority: Option<u64>,
     /// The regions where the record is propagated. This is optional.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub regions: Option<Vec<String>>,
 }
 


### PR DESCRIPTION
if the plan doesn't support regions then even if the ZoneRecordPayload specifies None it gets serialized and i get an api error: 'Regions are not allowed for your plan'. It could be either that it needs updating on the api side or here with a quick fix to skip serializing if the field is None. 
I do not know how to modify the test as i don't know the api implementation on your side. Pointers welcome....