### PR TITLE
Remove from and to from EmailForwards

### DIFF
--- a/src/dnsimple/domains_email_forwards.rs
+++ b/src/dnsimple/domains_email_forwards.rs
@@ -20,12 +20,6 @@ pub struct EmailForward {
     pub alias_email: String,
     /// The destination email
     pub destination_email: String,
-    /// The "local part" of the originating email address. Anything to the left of the @ symbol.
-    #[deprecated(note = "use alias_email instead")]
-    pub from: String,
-    /// The full email address to forward to.
-    #[deprecated(note = "use destination_email instead")]
-    pub to: String,
     /// Whether the email forward is active
     pub active: bool,
     ///  When the email forward was created in DNSimple.
@@ -42,9 +36,9 @@ pub struct EmailForwardsInList {
     /// The domain id
     pub domain_id: u64,
     /// The "local part" of the originating email address. Anything to the left of the @ symbol.
-    pub from: String,
+    pub alias_email: String,
     /// The full email address to forward to.
-    pub to: String,
+    pub destination_email: String,
     /// Whether the email forward is active
     pub active: bool,
     ///  When the email forward was created in DNSimple.

--- a/tests/domains_email_forwards_test.rs
+++ b/tests/domains_email_forwards_test.rs
@@ -25,8 +25,8 @@ fn test_list_email_forwards() {
 
     assert_eq!(24809, email_forwards.id);
     assert_eq!(235146, email_forwards.domain_id);
-    assert_eq!(".*@a-domain.com", email_forwards.from);
-    assert_eq!("jane.smith@example.com", email_forwards.to);
+    assert_eq!(".*@a-domain.com", email_forwards.alias_email);
+    assert_eq!("jane.smith@example.com", email_forwards.destination_email);
     assert_eq!("2017-05-25T19:23:16Z", email_forwards.created_at);
     assert_eq!("2017-05-25T19:23:16Z", email_forwards.updated_at);
     assert!(email_forwards.active);
@@ -61,8 +61,6 @@ fn test_create_email_forward() {
     assert_eq!("example@example.com", record.destination_email);
     assert_eq!("2021-01-25T13:54:40Z", record.created_at);
     assert_eq!("2021-01-25T13:54:40Z", record.updated_at);
-    assert_eq!("example@dnsimple.xyz", record.from);
-    assert_eq!("example@example.com", record.to);
     assert!(record.active);
 }
 
@@ -92,8 +90,6 @@ fn test_get_email_forward() {
     assert_eq!("example@example.com", record.destination_email);
     assert_eq!("2021-01-25T13:54:40Z", record.created_at);
     assert_eq!("2021-01-25T13:54:40Z", record.updated_at);
-    assert_eq!("example@dnsimple.xyz", record.from);
-    assert_eq!("example@example.com", record.to);
     assert!(record.active);
 }
 


### PR DESCRIPTION
Belongs to https://github.com/dnsimple/dnsimple-app/issues/17733.

## Description
This PR removes the deprecated `from` and `to` models from the `EmailForward` model.