### PR TITLE
Add support for trustee service

### DIFF
--- a/src/dnsimple/domains.rs
+++ b/src/dnsimple/domains.rs
@@ -21,6 +21,9 @@ pub struct Domain {
     pub auto_renew: bool,
     /// Set to true if the domain is WHOIS protected
     pub private_whois: bool,
+    /// True if the trustee service is enabled for the domain.
+    #[serde(default)]
+    pub trustee_service: bool,
     /// The day the domain will expire
     pub expires_on: Option<String>,
     /// The exact expiration time of the domain

--- a/src/dnsimple/registrar.rs
+++ b/src/dnsimple/registrar.rs
@@ -27,6 +27,8 @@ pub struct DomainPrice {
     pub renewal_price: f32,
     /// The price for transfer
     pub transfer_price: f32,
+    /// The trustee service price (if supported by the TLD).
+    pub trustee_service_price: Option<f32>,
 }
 
 /// The payload to register a domain
@@ -37,6 +39,9 @@ pub struct DomainRegistrationPayload {
     /// True if the domain WHOIS privacy was requested.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub whois_privacy: Option<bool>,
+    /// True if the trustee service was requested.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trustee_service: Option<bool>,
     /// True if the domain auto-renew was requested.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auto_renew: Option<bool>,
@@ -65,6 +70,8 @@ pub struct DomainRegistration {
     pub auto_renew: bool,
     /// True if the domain WHOIS privacy was requested.
     pub whois_privacy: bool,
+    /// True if the trustee service was enabled for the domain.
+    pub trustee_service: bool,
     /// When the domain renewal was created in DNSimple.
     pub created_at: String,
     /// When the domain renewal was last updated in DNSimple.
@@ -301,6 +308,7 @@ impl Registrar<'_> {
     /// let payload = DomainRegistrationPayload {
     ///     registrant_id: 42,
     ///     whois_privacy: None,
+    ///     trustee_service: None,
     ///     auto_renew: None,
     ///     extended_attributes: None,
     ///     premium_price: None,

--- a/src/dnsimple/tlds.rs
+++ b/src/dnsimple/tlds.rs
@@ -12,6 +12,10 @@ pub struct Tld {
     pub tld_type: u64,
     /// True if Whois Privacy Protection is available.
     pub whois_privacy: bool,
+    /// True if Trustee service is available.
+    pub trustee_service_enabled: bool,
+    /// True if Trustee service is required.
+    pub trustee_service_required: bool,
     ///  True if TLD requires use of auto-renewal for renewals.
     pub auto_renew_only: bool,
     /// True if IDN is available.

--- a/tests/domains_test.rs
+++ b/tests/domains_test.rs
@@ -80,6 +80,7 @@ fn test_get_domain() {
     assert_eq!("registered", domain.state);
     assert!(!domain.auto_renew);
     assert!(!domain.private_whois);
+    assert!(!domain.trustee_service);
     assert_eq!("2021-06-05", domain.expires_on.unwrap());
     assert_eq!("2021-06-05T02:15:00Z", domain.expires_at.unwrap());
     assert_eq!("2020-06-04T19:15:14Z", domain.created_at);

--- a/tests/registrar_test.rs
+++ b/tests/registrar_test.rs
@@ -45,6 +45,9 @@ fn test_get_domain_prices() {
     assert_eq!(20.0, domain_prices.registration_price);
     assert_eq!(20.0, domain_prices.renewal_price);
     assert_eq!(20.0, domain_prices.transfer_price);
+    if let Some(trustee_service_price) = domain_prices.trustee_service_price {
+        assert_eq!(20.0, trustee_service_price);
+    }
 }
 
 #[test]
@@ -89,6 +92,7 @@ fn test_get_domain_registration() {
     assert_eq!(domain_registration.state, "registering");
     assert!(!domain_registration.auto_renew);
     assert!(!domain_registration.whois_privacy);
+    assert!(!domain_registration.trustee_service);
     assert_eq!(domain_registration.created_at, "2023-01-27T17:44:32Z");
     assert_eq!(domain_registration.updated_at, "2023-01-27T17:44:40Z");
 }
@@ -132,6 +136,7 @@ fn test_register_domain() {
     let payload = DomainRegistrationPayload {
         registrant_id: 2,
         whois_privacy: None,
+        trustee_service: None,
         auto_renew: None,
         extended_attributes: None,
         premium_price: None,
@@ -150,6 +155,7 @@ fn test_register_domain() {
     assert_eq!("new", domain_registration.state);
     assert!(!domain_registration.auto_renew);
     assert!(!domain_registration.whois_privacy);
+    assert!(!domain_registration.trustee_service);
     assert_eq!("2016-12-09T19:35:31Z", domain_registration.created_at);
     assert_eq!("2016-12-09T19:35:31Z", domain_registration.updated_at);
 }

--- a/tests/tlds_test.rs
+++ b/tests/tlds_test.rs
@@ -16,6 +16,8 @@ fn test_list_tlds() {
     assert_eq!("ac", tld.tld);
     assert_eq!(2, tld.tld_type);
     assert!(!tld.whois_privacy);
+    assert!(!tld.trustee_service_enabled);
+    assert!(!tld.trustee_service_required);
     assert!(tld.auto_renew_only);
     assert!(!tld.idn);
     assert_eq!(1, tld.minimum_registration);
@@ -36,6 +38,8 @@ fn test_get_tld() {
     assert_eq!("com", tld.tld);
     assert_eq!(1, tld.tld_type);
     assert!(tld.whois_privacy);
+    assert!(!tld.trustee_service_enabled);
+    assert!(!tld.trustee_service_required);
     assert!(!tld.auto_renew_only);
     assert!(tld.idn);
     assert_eq!(1, tld.minimum_registration);


### PR DESCRIPTION
Belongs to https://github.com/dnsimple/dnsimple-business/issues/2525

Add support for trustee service

## :mag: QA

From the rake console

```rust
//! From the repository root:
//!   1. `cargo run --bin test_local`

use std::collections::HashMap;

use dnsimple::dnsimple::registrar::DomainRegistrationPayload;
use dnsimple::dnsimple::{new_client, Client, Filters, RequestOptions};

fn main() {
    let account_id: u64 = 2;
    let registrant_id: u64 = 1;
    let tld_name = "com";
    let domain_name = "asdf.com";
    let new_domain_name = "rustdomain";

    let token = "dnsimpletest_a_FSYtfYn7p74jfPd3GBUUsnLoOXia8hkR";
    let mut client: Client = new_client(false, String::from(token));
    client.set_base_url("http://api.localhost:5000");

    let list = client
        .tlds()
        .list_tlds(None)
        .expect("list_tlds");
    for t in list.data.expect("tlds data") {
        println!(
            "tld={} trustee_service_enabled={} trustee_service_required={}",
            t.tld, t.trustee_service_enabled, t.trustee_service_required
        );
    }

    let tld = client
        .tlds()
        .get_tld(String::from(tld_name))
        .expect("get_tld");
    let t = tld.data.expect("tld data");
    println!(
        "tld={} trustee_service_enabled={} trustee_service_required={}",
        t.tld, t.trustee_service_enabled, t.trustee_service_required
    );

    let mut filters = HashMap::new();
    filters.insert("name_like".to_string(), domain_name.to_string());
    let list_opts = RequestOptions {
        filters: Some(Filters { filters }),
        sort: None,
        paginate: None,
    };
    let listed = client
        .domains()
        .list_domains(account_id, Some(list_opts))
        .expect("list_domains");
    let domain_id = listed
        .data
        .as_ref()
        .and_then(|domains| domains.first())
        .map(|d| d.id)
        .expect("domain not found in account (check domain_name)");

    let domain = client
        .domains()
        .get_domain(account_id, domain_id)
        .expect("get_domain");
    let d = domain.data.expect("domain data");
    println!("domain={} trustee_service={}", d.name, d.trustee_service);

    let prices = client
        .registrar()
        .get_domain_prices(account_id, domain_name)
        .expect("get_domain_prices");
    let p = prices.data.expect("prices data");
    println!(
        "prices domain={} trustee_service_price={:?}",
        p.domain, p.trustee_service_price
    );

    let registration = client
        .registrar()
        .register_domain(
            account_id,
            &format!("{new_domain_name}.com"),
            DomainRegistrationPayload {
                registrant_id,
                whois_privacy: None,
                trustee_service: None,
                auto_renew: None,
                extended_attributes: None,
                premium_price: None,
            },
        )
        .expect("register_domain");
    let r = registration.data.expect("registration data");
    println!(
        "registration domain_id={} trustee_service={}",
        r.domain_id, r.trustee_service
    );
}


```


## :clipboard: Deployment Pre/Post tasks

- [x] POST: Create a release version https://github.com/dnsimple/dnsimple-rust/blob/main/RELEASING.md


## :shipit: Deployment Verification

- [x] QAd
