### PR TITLE
Add domain push identifier support and account name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+- Added `new_account_identifier` to `InitiatePushPayload` for initiating domain pushes by account identifier.
+- Added `name` to `Account`.
+
+### Deprecated
+
+- Deprecated `new_account_email` in `InitiatePushPayload`. Use `new_account_identifier` instead.
+
 ## 5.2.0 - 2026-03-23
 
 ### Added

--- a/src/dnsimple/domains_push.rs
+++ b/src/dnsimple/domains_push.rs
@@ -37,8 +37,12 @@ pub struct DomainPush {
 /// Payload to initiate a push
 #[derive(Debug, Deserialize, Serialize)]
 pub struct InitiatePushPayload {
-    /// The email address of the target DNSimple account.
-    pub new_account_email: String,
+    /// Deprecated: Use `new_domain_push_identifier` instead.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_account_email: Option<String>,
+    /// The domain push identifier of the target account.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_domain_push_identifier: Option<String>,
 }
 
 /// The domains push set of endpoints
@@ -55,7 +59,8 @@ impl Domains<'_> {
     ///
     /// let client = new_client(true, String::from("AUTH_TOKEN"));
     /// let payload = InitiatePushPayload {
-    ///     new_account_email: String::from("admin@target-account.test"),
+    ///     new_account_email: None,
+    ///     new_domain_push_identifier: Some(String::from("abc123")),
     /// };
     /// let push = client.domains().initiate_push(1234, "example.com", payload).unwrap().data.unwrap();
     /// ```

--- a/src/dnsimple/domains_push.rs
+++ b/src/dnsimple/domains_push.rs
@@ -37,12 +37,12 @@ pub struct DomainPush {
 /// Payload to initiate a push
 #[derive(Debug, Deserialize, Serialize)]
 pub struct InitiatePushPayload {
-    /// Deprecated: Use `new_domain_push_identifier` instead.
+    /// Deprecated: Use `new_account_identifier` instead.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub new_account_email: Option<String>,
-    /// The domain push identifier of the target account.
+    /// The identifier of the target account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub new_domain_push_identifier: Option<String>,
+    pub new_account_identifier: Option<String>,
 }
 
 /// The domains push set of endpoints
@@ -60,7 +60,7 @@ impl Domains<'_> {
     /// let client = new_client(true, String::from("AUTH_TOKEN"));
     /// let payload = InitiatePushPayload {
     ///     new_account_email: None,
-    ///     new_domain_push_identifier: Some(String::from("abc123")),
+    ///     new_account_identifier: Some(String::from("abc123")),
     /// };
     /// let push = client.domains().initiate_push(1234, "example.com", payload).unwrap().data.unwrap();
     /// ```

--- a/src/dnsimple/identity.rs
+++ b/src/dnsimple/identity.rs
@@ -23,6 +23,8 @@ pub struct Account {
     pub id: u64,
     /// The account email
     pub email: String,
+    /// The account name
+    pub name: Option<String>,
     /// The identifier of the plan the account is subscribed to
     pub plan_identifier: String,
     /// When the account was created in DNSimple
@@ -92,11 +94,13 @@ mod tests {
         let account = identity::Account {
             id: 14,
             email: String::from("account@dnsimple.com"),
+            name: Some(String::from("Test Account")),
             plan_identifier: String::from("testing_plan"),
             created_at: String::from("some_time_ago"),
             updated_at: String::from("recently"),
         };
 
-        assert_eq!("testing_plan", account.plan_identifier)
+        assert_eq!("testing_plan", account.plan_identifier);
+        assert_eq!(Some(String::from("Test Account")), account.name)
     }
 }

--- a/tests/accounts_test.rs
+++ b/tests/accounts_test.rs
@@ -14,6 +14,7 @@ fn list_accounts_account_success() {
     let account = accounts.first().unwrap();
     assert_eq!(123, account.id);
     assert_eq!("john@example.com", account.email);
+    assert_eq!(Some(String::from("John")), account.name);
     assert_eq!("dnsimple-personal", account.plan_identifier);
 }
 

--- a/tests/domains_push_test.rs
+++ b/tests/domains_push_test.rs
@@ -14,7 +14,7 @@ fn test_initiate_push_test() {
     let domain = "target-account.test";
     let payload = InitiatePushPayload {
         new_account_email: Some(String::from("admin@target-account.test")),
-        new_domain_push_identifier: None,
+        new_account_identifier: None,
     };
 
     let push = client
@@ -34,7 +34,7 @@ fn test_initiate_push_test() {
 }
 
 #[test]
-fn test_initiate_push_with_domain_push_identifier() {
+fn test_initiate_push_with_account_identifier() {
     let setup = setup_mock_for(
         "/1385/domains/target-account.test/pushes",
         "initiatePush/success",
@@ -45,7 +45,7 @@ fn test_initiate_push_with_domain_push_identifier() {
     let domain = "target-account.test";
     let payload = InitiatePushPayload {
         new_account_email: None,
-        new_domain_push_identifier: Some(String::from("abc123")),
+        new_account_identifier: Some(String::from("abc123")),
     };
 
     let push = client

--- a/tests/domains_push_test.rs
+++ b/tests/domains_push_test.rs
@@ -13,7 +13,8 @@ fn test_initiate_push_test() {
     let account_id = 1385_u64;
     let domain = "target-account.test";
     let payload = InitiatePushPayload {
-        new_account_email: String::from("admin@target-account.test"),
+        new_account_email: Some(String::from("admin@target-account.test")),
+        new_domain_push_identifier: None,
     };
 
     let push = client
@@ -30,6 +31,32 @@ fn test_initiate_push_test() {
     assert_eq!("2016-08-11T10:16:03Z", push.created_at);
     assert_eq!("2016-08-11T10:16:03Z", push.updated_at);
     assert_eq!(None, push.accepted_at);
+}
+
+#[test]
+fn test_initiate_push_with_domain_push_identifier() {
+    let setup = setup_mock_for(
+        "/1385/domains/target-account.test/pushes",
+        "initiatePush/success",
+        "POST",
+    );
+    let client = setup.0;
+    let account_id = 1385_u64;
+    let domain = "target-account.test";
+    let payload = InitiatePushPayload {
+        new_account_email: None,
+        new_domain_push_identifier: Some(String::from("abc123")),
+    };
+
+    let push = client
+        .domains()
+        .initiate_push(account_id, domain, payload)
+        .unwrap()
+        .data
+        .unwrap();
+
+    assert_eq!(1, push.id);
+    assert_eq!(2020, push.account_id);
 }
 
 #[test]

--- a/tests/fixtures/v2/api/accounts/success-account.http
+++ b/tests/fixtures/v2/api/accounts/success-account.http
@@ -17,4 +17,4 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}

--- a/tests/fixtures/v2/api/accounts/success-user.http
+++ b/tests/fixtures/v2/api/accounts/success-user.http
@@ -17,5 +17,5 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","name":"Ops Company","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}
 

--- a/tests/fixtures/v2/api/listAccounts/success-account.http
+++ b/tests/fixtures/v2/api/listAccounts/success-account.http
@@ -17,4 +17,4 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}

--- a/tests/fixtures/v2/api/listAccounts/success-user.http
+++ b/tests/fixtures/v2/api/listAccounts/success-user.http
@@ -17,4 +17,4 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","name":"Ops Company","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}

--- a/tests/fixtures/v2/api/whoami/success-account.http
+++ b/tests/fixtures/v2/api/whoami/success-account.http
@@ -12,4 +12,4 @@ x-request-id: 15a7f3a5-7ee5-4e36-ac5a-8c21c2e1fffd
 x-runtime: 0.141588
 strict-transport-security: max-age=31536000
 
-{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}
+{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","name":"Example Account","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}

--- a/tests/fixtures/v2/api/whoami/success.http
+++ b/tests/fixtures/v2/api/whoami/success.http
@@ -12,4 +12,4 @@ x-request-id: 15a7f3a5-7ee5-4e36-ac5a-8c21c2e1fffd
 x-runtime: 0.141588
 strict-transport-security: max-age=31536000
 
-{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}
+{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","name":"Example Account","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}

--- a/tests/identity_test.rs
+++ b/tests/identity_test.rs
@@ -12,6 +12,7 @@ fn whoami_success_with_account() {
 
     assert_eq!(1, account.id);
     assert_eq!("example-account@example.com", account.email);
+    assert_eq!(Some(String::from("Example Account")), account.name);
     assert_eq!("teams-v1-monthly", account.plan_identifier);
 }
 


### PR DESCRIPTION
## Summary
- Add `new_domain_push_identifier` field to `InitiatePushPayload`
- Deprecate `new_account_email` in favor of `new_domain_push_identifier`
- Add `name` field to `Account` struct
- Update fixtures and tests

Closes dnsimple/dnsimple-engineering#425