### PR TITLE
Support trustee service in transfers

### DIFF
--- a/src/dnsimple/registrar.rs
+++ b/src/dnsimple/registrar.rs
@@ -88,6 +88,9 @@ pub struct DomainTransferPayload {
     /// True if the domain WHOIS privacy was requested.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub whois_privacy: Option<bool>,
+    /// True if the trustee service was requested.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trustee_service: Option<bool>,
     /// True if the domain auto-renew was requested.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auto_renew: Option<bool>,
@@ -114,6 +117,8 @@ pub struct DomainTransfer {
     pub auto_renew: bool,
     /// True if the domain WHOIS privacy was requested.
     pub whois_privacy: bool,
+    /// True if the trustee service was enabled for the domain.
+    pub trustee_service: bool,
     /// The reason if transfer failed.
     pub status_description: Option<String>,
     /// When the domain renewal was created in DNSimple.

--- a/src/dnsimple/registrar.rs
+++ b/src/dnsimple/registrar.rs
@@ -355,6 +355,7 @@ impl Registrar<'_> {
     ///     registrant_id: 42,
     ///     auth_code: "Some code".to_string(),
     ///     whois_privacy: None,
+    ///     trustee_service: None,
     ///     auto_renew: None,
     ///     extended_attributes: None,
     ///     premium_price: None,

--- a/tests/registrar_test.rs
+++ b/tests/registrar_test.rs
@@ -174,6 +174,7 @@ fn test_transfer_domain() {
         registrant_id: 2,
         auth_code: String::from("THE_AUTH_CODE"),
         whois_privacy: None,
+        trustee_service: None,
         auto_renew: None,
         extended_attributes: None,
         premium_price: None,
@@ -191,6 +192,7 @@ fn test_transfer_domain() {
     assert_eq!("transferring", domain_transfer.state);
     assert!(!domain_transfer.auto_renew);
     assert!(!domain_transfer.whois_privacy);
+    assert!(!domain_transfer.trustee_service);
     assert_eq!("2016-12-09T19:43:41Z", domain_transfer.created_at);
     assert_eq!("2016-12-09T19:43:43Z", domain_transfer.updated_at);
 }
@@ -209,6 +211,7 @@ fn test_transfer_domain_error_in_dnsimple() {
         registrant_id: 2,
         auth_code: String::from("THE_AUTH_CODE"),
         whois_privacy: None,
+        trustee_service: None,
         auto_renew: None,
         extended_attributes: None,
         premium_price: None,
@@ -239,6 +242,7 @@ fn test_transfer_domain_error_missing_auth_code() {
         registrant_id: 2,
         auth_code: String::from(""),
         whois_privacy: None,
+        trustee_service: None,
         auto_renew: None,
         extended_attributes: None,
         premium_price: None,
@@ -276,6 +280,7 @@ fn test_retrieve_domain_transfer() {
     assert_eq!("cancelled", transfer.state);
     assert!(!transfer.auto_renew);
     assert!(!transfer.whois_privacy);
+    assert!(!transfer.trustee_service);
     assert_eq!("Canceled by customer", transfer.status_description.unwrap());
     assert_eq!("2020-06-05T18:08:00Z", transfer.created_at);
     assert_eq!("2020-06-05T18:10:01Z", transfer.updated_at);
@@ -308,6 +313,7 @@ fn test_cancel_domain_transfer() {
     assert_eq!("transferring", transfer.state);
     assert!(!transfer.auto_renew);
     assert!(!transfer.whois_privacy);
+    assert!(!transfer.trustee_service);
     assert_eq!(None, transfer.status_description);
     assert_eq!("2020-06-05T18:08:00Z", transfer.created_at);
     assert_eq!("2020-06-05T18:08:04Z", transfer.updated_at);


### PR DESCRIPTION
Updated **src/dnsimple/registrar.rs**
- Added `trustee_service: Option<bool>` field to `DomainTransferPayload` so callers can opt into the trustee service when initiating a transfer
- Added `trustee_service: bool` field to the `DomainTransfer` response struct so the value is parsed from API responses

Addresses https://github.com/dnsimple/dnsimple-app/issues/34691
Belongs to https://github.com/dnsimple/dnsimple-business/issues/2641

### QA

(Optional for reviewers)

From the console (adjust `account_id`, `registrant_id`, `domain_name` and `base_url` accordingly) run `TOKEN=… cargo run --bin qa_transfer_trustee`

```rust
use dnsimple::dnsimple::registrar::DomainTransferPayload;
use dnsimple::dnsimple::{new_client, Client};

fn main() {
    let token = std::env::var("TOKEN").expect("ERROR: TOKEN environment variable is required");
    let account_id: u64 = 2;
    let registrant_id: u64 = 27;
    let domain_name = "example.com";

    let mut client: Client = new_client(false, token);
    client.set_base_url("http://api.dnsimple.localhost:3000");

    let transfer = client
        .registrar()
        .transfer_domain(account_id, domain_name, DomainTransferPayload {
            registrant_id,
            auth_code: String::from("x1y2z3"),
            whois_privacy: None,
            trustee_service: Some(true),
            auto_renew: None,
            extended_attributes: None,
            premium_price: None,
        })
        .expect("transfer_domain");
    let t = transfer.data.expect("transfer data");
    println!("transfer domain_id={} trustee_service={} state={}", t.domain_id, t.trustee_service, t.state);

    let got = client
        .registrar()
        .get_domain_transfer(account_id, String::from(domain_name), t.id)
        .expect("get_domain_transfer");
    let t = got.data.expect("transfer data");
    println!("get_transfer id={} trustee_service={} state={}", t.id, t.trustee_service, t.state);
}
```

#### QA results

```
BadRequest { message: "TLD .COM does not support trustee service", attribute_errors: Some(Null) }
```

```
BadRequest { message: "Unable to complete transfer at the registrar. Invalid attribute value syntax [Parameter value syntax error; Invalid transfer authorisation code]", attribute_errors: Some(Object {}) }
```

### Deployment Pre/Post tasks

- [x] PRE: Wait till release is ready to be made
- [x] POST: Create a release version

### Deployment Verification

- [x] Verify release is created