### PR TITLE
Remove deprecated Certificate contact_id field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## main
+
+### Removed
+
+- **BREAKING**: Removed the deprecated `contact_id` field from the `Certificate` struct. The field was deprecated on 2022-05-17 and is no longer required for certificate operations. Closes #105.
+
 ## 5.3.0 - 2026-04-15
 
 ### Added

--- a/src/dnsimple/certificates.rs
+++ b/src/dnsimple/certificates.rs
@@ -10,9 +10,6 @@ pub struct Certificate {
     pub id: u64,
     /// The associated domain ID.
     pub domain_id: u64,
-    /// The associated contact ID.
-    #[deprecated]
-    pub contact_id: u64,
     /// The certificate name.
     pub name: String,
     /// The certificate common name.

--- a/tests/certificates_test.rs
+++ b/tests/certificates_test.rs
@@ -28,7 +28,6 @@ fn test_list_certificates() {
 
     assert_eq!(101973, certificate.id);
     assert_eq!(14279, certificate.domain_id);
-    assert_eq!(11435, certificate.contact_id);
     assert_eq!("www2", certificate.name);
     assert_eq!("www2.dnsimple.us", certificate.common_name);
     assert_eq!(1, certificate.years);
@@ -69,7 +68,6 @@ fn test_get_certificate() {
 
     assert_eq!(101967, certificate.id);
     assert_eq!(289333, certificate.domain_id);
-    assert_eq!(2511, certificate.contact_id);
     assert_eq!("www", certificate.name);
     assert_eq!("www.bingo.pizza", certificate.common_name);
     assert_eq!(1, certificate.years);
@@ -193,7 +191,6 @@ fn test_issue_letsencrypt_certificate() {
 
     assert_eq!(101967, certificate.id);
     assert_eq!(289333, certificate.domain_id);
-    assert_eq!(2511, certificate.contact_id);
     assert_eq!("www", certificate.name);
     assert_eq!("www.bingo.pizza", certificate.common_name);
     assert_eq!(1, certificate.years);
@@ -269,7 +266,6 @@ fn test_issue_letsencrypt_certificate_renewal() {
 
     assert_eq!(101972, renewal.id);
     assert_eq!(289333, renewal.domain_id);
-    assert_eq!(2511, renewal.contact_id);
     assert_eq!("www", renewal.name);
     assert_eq!("www.bingo.pizza", renewal.common_name);
     assert_eq!(1, renewal.years);


### PR DESCRIPTION
## Summary

Remove the deprecated `contact_id` field from the `Certificate` struct. The field was deprecated on 2022-05-17 and is no longer required for certificate operations.

This is a breaking change.

Closes #105.

Tracking PR: dnsimple/dnsimple-developer#987

## Test plan

- [x] `cargo test` passes